### PR TITLE
Make MarkdownHandler rails 5 compatible by implementing a proxy class.

### DIFF
--- a/lib/elemental_styleguide.rb
+++ b/lib/elemental_styleguide.rb
@@ -3,6 +3,7 @@
 require "redcarpet"
 require "rouge"
 require "rouge/plugins/redcarpet"
+require "elemental_styleguide/markdown_handler_rails5"
 require "elemental_styleguide/markdown_handler"
 require "elemental_styleguide/markdown_renderer"
 require "elemental_styleguide/engine"

--- a/lib/elemental_styleguide/engine.rb
+++ b/lib/elemental_styleguide/engine.rb
@@ -8,7 +8,7 @@ module ElementalStyleguide
       if Rails::VERSION::MAJOR < 6
         ActionView::Template.register_template_handler :md, ElementalStyleguide::MarkdownHandlerRails5
       else
-        ActionView::Template.register_template_handler :md, ElementalStyleguide::MarkdownHandlerRails
+        ActionView::Template.register_template_handler :md, ElementalStyleguide::MarkdownHandler
       end
     end
   end

--- a/lib/elemental_styleguide/engine.rb
+++ b/lib/elemental_styleguide/engine.rb
@@ -5,7 +5,11 @@ module ElementalStyleguide
     isolate_namespace ElementalStyleguide
 
     initializer "elemental_styleguide.template_hander" do
-      ActionView::Template.register_template_handler :md, ElementalStyleguide::MarkdownHandler
+      if Rails::VERSION::MAJOR < 6
+        ActionView::Template.register_template_handler :md, ElementalStyleguide::MarkdownHandlerRails5
+      else
+        ActionView::Template.register_template_handler :md, ElementalStyleguide::MarkdownHandlerRails
+      end
     end
   end
 end

--- a/lib/elemental_styleguide/markdown_handler_rails5.rb
+++ b/lib/elemental_styleguide/markdown_handler_rails5.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module ElementalStyleguide
+  # Support rails 5 template handlers by defining a proxy class without "source" parameter in .call signature.
+  class MarkdownHandlerRails5
+    class << self
+      def call(template)
+        # Forward method call to rails 6 compatible MarkdownHandler with additional, fake "source" parameter.
+        ElementalStyleguide::MarkdownHandler.call(template, nil)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Resolve #14 by defining a rails 5 specific proxy class. It forwards the method call to the rails 6 compatible MarkdownHandler and adds a fake `source` param with nil value.